### PR TITLE
Fixed tests + moved mocha to be peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "mocha-teamcity-reporter": "1.1.1"
   },
   "peerDependencies": {
-    "mocha": ">=2"
+    "mocha": ">=2.4.5"
   },
   "devDependencies": {
     "mocha": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-env-reporter",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "ci/dev environment aware mocha reporter",
   "author": "Vilius Lukosius <vilius@wix.com>",
   "license": "SEE LICENSE IN LICENSE.md",
@@ -24,10 +24,13 @@
     "url": "https://github.com/wix/mocha-env-reporter/issues"
   },
   "dependencies": {
-    "mocha": "3.0.2",
     "mocha-teamcity-reporter": "1.1.1"
   },
+  "peerDependencies": {
+    "mocha": ">=2"
+  },
   "devDependencies": {
+    "mocha": "3.0.2",
     "chai": "3.5.0",
     "jshint": "2.9.3",
     "shelljs": "0.7.4"

--- a/test/mocha-ci-reporter.spec.js
+++ b/test/mocha-ci-reporter.spec.js
@@ -3,9 +3,9 @@ var expect = require('chai').expect,
   shelljs = require('shelljs');
 
 function run() {
-  var out = shelljs.exec('./node_modules/mocha/bin/mocha ./test/embedded/test.js --reporter index');
+  var out = shelljs.exec('./node_modules/mocha/bin/mocha test/embedded/test.js --reporter index');
   expect(out.code).to.equal(0);
-  return out.output;
+  return out.stdout;
 }
 
 describe('mocha ci reporter', function() {


### PR DESCRIPTION
Usually client project has mocha as dependency (and it should) so mocha-env-reporter should not pull it in because:
- library uses fixed version and versions will mismatch - extra deps and size;
- client should decide on mocha version and library just define valid bounds.
